### PR TITLE
fix: Add type=module to script tags

### DIFF
--- a/gamehub.html
+++ b/gamehub.html
@@ -21,7 +21,7 @@
             </div>
         </div>
     </main>
-    <script src="header.js"></script>
-    <script src="script.js"></script>
+    <script src="header.js" type="module"></script>
+    <script src="script.js" type="module"></script>
 </body>
 </html>


### PR DESCRIPTION
- Adds `type="module"` to the script tags for `header.js` and `script.js` in `gamehub.html` to resolve a console error.